### PR TITLE
Fix for CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')

### DIFF
--- a/src/main/java/org/owasp/webgoat/container/lessons/LessonConnectionInvocationHandler.java
+++ b/src/main/java/org/owasp/webgoat/container/lessons/LessonConnectionInvocationHandler.java
@@ -27,7 +27,10 @@ public class LessonConnectionInvocationHandler implements InvocationHandler {
         var authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.getPrincipal() instanceof WebGoatUser user) {
             try (var statement = targetConnection.createStatement()) {
-                statement.execute("SET SCHEMA \"" + user.getUsername() + "\"");
+                try (var preparedStatement = targetConnection.prepareStatement("SET SCHEMA ?")) {
+                    preparedStatement.setString(1, user.getUsername());
+                    preparedStatement.execute();
+                }
             }
         }
         try {


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in src/main/java/org/owasp/webgoat/container/lessons/LessonConnectionInvocationHandler.java.

It is CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection') that has a severity of :red_circle: High.

### 🪄 Fix explanation
The fix mitigates SQL injection by replacing a dynamic SQL statement with a prepared statement, ensuring user input is treated as data rather than executable code.<br>-Replaced &quot;statement.execute(&quot;SET SCHEMA \&quot;&quot; + user.getUsername() + &quot;\&quot;&quot;)&quot; with a prepared statement to prevent SQL injection.<br>    -Introduced &quot;targetConnection.prepareStatement(&quot;SET SCHEMA ?&quot;)&quot; to safely handle user input.<br>    -Used &quot;preparedStatement.setString(1, user.getUsername())&quot; to bind the username parameter, ensuring it is treated as data.<br>    -Executed the prepared statement with &quot;preparedStatement.execute()&quot;, maintaining the intended functionality.

### 💡 Important Instructions
Ensure all other SQL interactions in the codebase use prepared statements to prevent similar vulnerabilities.

[See the issue and fix in Corgea.](https://www.corgea.app/issue/29952d50-7d1a-4d56-bde3-23d2d97c291f)

